### PR TITLE
check if span is recording before finalizing

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -396,6 +396,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
     lambdaResponse: any,
     errorFromLambda: string | Error | null | undefined,
   ) {
+    if(!span.isRecording()){
+      return;
+    }
+
     if (errorFromLambda) {
       span.recordException(errorFromLambda);
 
@@ -468,6 +472,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
   }
 
   private _endSpan(span: Span, err: string | Error | null | undefined) {
+    if(!span.isRecording()) {
+      return;
+    }
+
     if (err) {
       span.recordException(err);
     }


### PR DESCRIPTION
check if span is ended before finalizing it, should resolve warning about operations being done after