### PR TITLE
Feature/ngstn 726 sst support

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -201,7 +201,6 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
         module,
         ['*'],
         (moduleExports: LambdaModule) => {
-          console.log('Applying patch for lambda handler 2')
           diag.debug('Applying patch for lambda handler');
           if (isWrapped(moduleExports[functionName])) {
             this._unwrap(moduleExports, functionName);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -79,9 +79,6 @@ const headerGetter: TextMapGetter<APIGatewayProxyEventHeaders> = {
 export const traceContextEnvironmentKey = '_X_AMZN_TRACE_ID';
 export const xForwardProto = 'X-Forwarded-Proto';
 
-console.log("console.log works")
-diag.debug('diag.debug works')
-
 export class AwsLambdaInstrumentation extends InstrumentationBase {
   private triggerOrigin: TriggerOrigin | undefined;
   private _traceForceFlusher?: () => Promise<void>;

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -205,7 +205,6 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
         filename,
         ['*'],
         (moduleExports: LambdaModule) => {
-          console.log('Applying patch for lambda handler 3')
           diag.debug('Applying patch for lambda handler');
           if (isWrapped(moduleExports[functionName])) {
             this._unwrap(moduleExports, functionName);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -201,6 +201,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
         module,
         ['*'],
         (moduleExports: LambdaModule) => {
+          console.log('Applying patch for lambda handler 2')
           diag.debug('Applying patch for lambda handler');
           if (isWrapped(moduleExports[functionName])) {
             this._unwrap(moduleExports, functionName);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -215,6 +215,25 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
           this._unwrap(moduleExports, functionName);
         }
       ),
+      // This approach works when the handler is an .mjs file in the function source code
+      new InstrumentationNodeModuleDefinition(
+        filename,
+        ['*'],
+        (moduleExports: LambdaModule) => {
+          console.log('Applying patch for lambda handler 3')
+          diag.debug('Applying patch for lambda handler');
+          if (isWrapped(moduleExports[functionName])) {
+            this._unwrap(moduleExports, functionName);
+          }
+          this._wrap(moduleExports, functionName, this._getHandler());
+          return moduleExports;
+        },
+        (moduleExports?: LambdaModule) => {
+          if (moduleExports === undefined) return;
+          diag.debug('Removing patch for lambda handler');
+          this._unwrap(moduleExports, functionName);
+        }
+      ),
     ];
   }
 

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -146,16 +146,6 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       }
     }
 
-    console.log('Instrumenting lambda handler', {
-      taskRoot,
-      handlerDef,
-      handler,
-      moduleRoot,
-      module,
-      filename,
-      functionName,
-    })
-
     diag.debug('Instrumenting lambda handler', {
       taskRoot,
       handlerDef,
@@ -180,7 +170,6 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
             module,
             ['*'],
             (moduleExports: LambdaModule) => {
-              console.log('Applying patch for lambda handler')
               diag.debug('Applying patch for lambda handler');
               if (isWrapped(moduleExports[functionName])) {
                 this._unwrap(moduleExports, functionName);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -146,6 +146,16 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       }
     }
 
+    console.log('Instrumenting lambda handler', {
+      taskRoot,
+      handlerDef,
+      handler,
+      moduleRoot,
+      module,
+      filename,
+      functionName,
+    })
+
     diag.debug('Instrumenting lambda handler', {
       taskRoot,
       handlerDef,
@@ -170,6 +180,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
             module,
             ['*'],
             (moduleExports: LambdaModule) => {
+              console.log('Applying patch for lambda handler')
               diag.debug('Applying patch for lambda handler');
               if (isWrapped(moduleExports[functionName])) {
                 this._unwrap(moduleExports, functionName);


### PR DESCRIPTION
This PR extends the logic of applying lambda handler instrumetation in two ways. 
* Supporting handler defined in *.mjs files
* Adding additinal InstrumentationNodeModuleDefinition matching by filename, which turns out to be what is needed in a module environment with the import-in-the-middle-hook