### PR TITLE
Nodejs cx wrapper

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -52,7 +52,6 @@ import {
 import { AwsLambdaInstrumentationConfig, EventContextExtractor } from './types';
 import { VERSION } from './version';
 import { env } from 'process';
-// import { LambdaModule } from './internal-types';
 import { strict } from 'assert';
 import {
   finalizeSpan,

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -66,6 +66,9 @@ import {
   LambdaAttributes,
   TriggerOrigin,
 } from './triggers';
+
+diag.debug("Loading AwsLambdaInstrumentation")
+
 const awsPropagator = new AWSXRayPropagator();
 const headerGetter: TextMapGetter<APIGatewayProxyEventHeaders> = {
   keys(carrier): string[] {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
-import * as fs from 'fs';
+// import * as path from 'path';
+// import * as fs from 'fs';
 
 import {
   InstrumentationBase,
-  InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
-  isWrapped,
+  // InstrumentationNodeModuleDefinition,
+  // InstrumentationNodeModuleFile,
+  // isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import {
@@ -58,7 +58,7 @@ import {
 import { AwsLambdaInstrumentationConfig, EventContextExtractor } from './types';
 import { VERSION } from './version';
 import { env } from 'process';
-import { LambdaModule } from './internal-types';
+// import { LambdaModule } from './internal-types';
 import { strict } from 'assert';
 import {
   finalizeSpan,
@@ -104,127 +104,132 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
   }
 
   init() {
-    const taskRoot = process.env.LAMBDA_TASK_ROOT;
-    const handlerDef = this._config.lambdaHandler ?? process.env._HANDLER;
+    // const taskRoot = process.env.LAMBDA_TASK_ROOT;
+    // const handlerDef = this._config.lambdaHandler ?? process.env._HANDLER;
 
-    // _HANDLER and LAMBDA_TASK_ROOT are always defined in Lambda but guard bail out if in the future this changes.
-    if (!taskRoot || !handlerDef) {
-      this._diag.debug(
-        'Skipping lambda instrumentation: no _HANDLER/lambdaHandler or LAMBDA_TASK_ROOT.',
-        { taskRoot, handlerDef }
-      );
-      return [];
-    }
+    // // _HANDLER and LAMBDA_TASK_ROOT are always defined in Lambda but guard bail out if in the future this changes.
+    // if (!taskRoot || !handlerDef) {
+    //   this._diag.debug(
+    //     'Skipping lambda instrumentation: no _HANDLER/lambdaHandler or LAMBDA_TASK_ROOT.',
+    //     { taskRoot, handlerDef }
+    //   );
+    //   return [];
+    // }
 
-    const handler = path.basename(handlerDef);
-    const moduleRoot = handlerDef.substr(0, handlerDef.length - handler.length);
+    // const handler = path.basename(handlerDef);
+    // const moduleRoot = handlerDef.substr(0, handlerDef.length - handler.length);
 
-    const [module, functionName] = handler.split('.', 2);
+    // const [module, functionName] = handler.split('.', 2);
 
-    // Lambda loads user function using an absolute path.
-    let filename = path.resolve(taskRoot, moduleRoot, module);
-    if (!filename.includes('.')) {
-      // The filename has no extension, we need to check if there is a .js, .cjs or .mjs file
-      try {
-        fs.statSync(`${filename}.js`);
-        filename += '.js';
-      } catch (e) {
-        try {
-          fs.statSync(`${filename}.cjs`);
-          filename += '.cjs';
-        } catch (e) {
-          try {
-            fs.statSync(`${filename}.mjs`);
-            filename += '.mjs';
-          } catch (e) {
-            diag.warn(`AwsLambdaInstrumentation couldn't find the handler file: ${filename}`);
-          }
-        }
-      }
-    }
+    // // Lambda loads user function using an absolute path.
+    // let filename = path.resolve(taskRoot, moduleRoot, module);
+    // if (!filename.includes('.')) {
+    //   // The filename has no extension, we need to check if there is a .js, .cjs or .mjs file
+    //   try {
+    //     fs.statSync(`${filename}.js`);
+    //     filename += '.js';
+    //   } catch (e) {
+    //     try {
+    //       fs.statSync(`${filename}.cjs`);
+    //       filename += '.cjs';
+    //     } catch (e) {
+    //       try {
+    //         fs.statSync(`${filename}.mjs`);
+    //         filename += '.mjs';
+    //       } catch (e) {
+    //         diag.warn(`AwsLambdaInstrumentation couldn't find the handler file: ${filename}`);
+    //       }
+    //     }
+    //   }
+    // }
 
-    diag.debug('Instrumenting lambda handler', {
-      taskRoot,
-      handlerDef,
-      handler,
-      moduleRoot,
-      module,
-      filename,
-      functionName,
-    });
+    // diag.debug('Instrumenting lambda handler', {
+    //   taskRoot,
+    //   handlerDef,
+    //   handler,
+    //   moduleRoot,
+    //   module,
+    //   filename,
+    //   functionName,
+    // });
 
-    return [
-      // This approach works when the handler is part of the function source code
-      new InstrumentationNodeModuleDefinition(
-        // NB: The patching infrastructure seems to match names backwards, this must be the filename, while
-        // InstrumentationNodeModuleFile must be the module name.
-        filename,
-        ['*'],
-        undefined,
-        undefined,
-        [
-          new InstrumentationNodeModuleFile(
-            module,
-            ['*'],
-            (moduleExports: LambdaModule) => {
-              diag.debug('Applying patch for lambda handler');
-              if (isWrapped(moduleExports[functionName])) {
-                this._unwrap(moduleExports, functionName);
-              }
-              this._wrap(moduleExports, functionName, this._getHandler());
-              return moduleExports;
-            },
-            (moduleExports?: LambdaModule) => {
-              if (moduleExports == null) return;
-              diag.debug('Removing patch for lambda handler');
-              this._unwrap(moduleExports, functionName);
-            }
-          ),
-        ]
-      ),
-      // This approach works when the handler is part of lambda layer
-      new InstrumentationNodeModuleDefinition(
-        module,
-        ['*'],
-        (moduleExports: LambdaModule) => {
-          diag.debug('Applying patch for lambda handler');
-          if (isWrapped(moduleExports[functionName])) {
-            this._unwrap(moduleExports, functionName);
-          }
-          this._wrap(moduleExports, functionName, this._getHandler());
-          return moduleExports;
-        },
-        (moduleExports?: LambdaModule) => {
-          if (moduleExports === undefined) return;
-          diag.debug('Removing patch for lambda handler');
-          this._unwrap(moduleExports, functionName);
-        }
-      ),
-      // This approach works when the handler is an .mjs file in the function source code
-      new InstrumentationNodeModuleDefinition(
-        filename,
-        ['*'],
-        (moduleExports: LambdaModule) => {
-          diag.debug('Applying patch for lambda handler');
-          if (isWrapped(moduleExports[functionName])) {
-            this._unwrap(moduleExports, functionName);
-          }
-          this._wrap(moduleExports, functionName, this._getHandler());
-          return moduleExports;
-        },
-        (moduleExports?: LambdaModule) => {
-          if (moduleExports === undefined) return;
-          diag.debug('Removing patch for lambda handler');
-          this._unwrap(moduleExports, functionName);
-        }
-      ),
-    ];
+    // return [
+    //   // This approach works when the handler is part of the function source code
+    //   new InstrumentationNodeModuleDefinition(
+    //     // NB: The patching infrastructure seems to match names backwards, this must be the filename, while
+    //     // InstrumentationNodeModuleFile must be the module name.
+    //     filename,
+    //     ['*'],
+    //     undefined,
+    //     undefined,
+    //     [
+    //       new InstrumentationNodeModuleFile(
+    //         module,
+    //         ['*'],
+    //         (moduleExports: LambdaModule) => {
+    //           diag.debug('Applying patch for lambda handler');
+    //           if (isWrapped(moduleExports[functionName])) {
+    //             this._unwrap(moduleExports, functionName);
+    //           }
+    //           this._wrap(moduleExports, functionName, this._getHandler());
+    //           return moduleExports;
+    //         },
+    //         (moduleExports?: LambdaModule) => {
+    //           if (moduleExports == null) return;
+    //           diag.debug('Removing patch for lambda handler');
+    //           this._unwrap(moduleExports, functionName);
+    //         }
+    //       ),
+    //     ]
+    //   ),
+    //   // This approach works when the handler is part of lambda layer
+    //   new InstrumentationNodeModuleDefinition(
+    //     module,
+    //     ['*'],
+    //     (moduleExports: LambdaModule) => {
+    //       diag.debug('Applying patch for lambda handler');
+    //       if (isWrapped(moduleExports[functionName])) {
+    //         this._unwrap(moduleExports, functionName);
+    //       }
+    //       this._wrap(moduleExports, functionName, this._getHandler());
+    //       return moduleExports;
+    //     },
+    //     (moduleExports?: LambdaModule) => {
+    //       if (moduleExports === undefined) return;
+    //       diag.debug('Removing patch for lambda handler');
+    //       this._unwrap(moduleExports, functionName);
+    //     }
+    //   ),
+    //   // This approach works when the handler is an .mjs file in the function source code
+    //   new InstrumentationNodeModuleDefinition(
+    //     filename,
+    //     ['*'],
+    //     (moduleExports: LambdaModule) => {
+    //       diag.debug('Applying patch for lambda handler');
+    //       if (isWrapped(moduleExports[functionName])) {
+    //         this._unwrap(moduleExports, functionName);
+    //       }
+    //       this._wrap(moduleExports, functionName, this._getHandler());
+    //       return moduleExports;
+    //     },
+    //     (moduleExports?: LambdaModule) => {
+    //       if (moduleExports === undefined) return;
+    //       diag.debug('Removing patch for lambda handler');
+    //       this._unwrap(moduleExports, functionName);
+    //     }
+    //   ),
+    // ];
+    return [];
   }
 
-  private _getHandler() {
-    return (original: Handler) => {
-      return this._getPatchHandler(original);
-    };
+  // private _getHandler() {
+  //   return (original: Handler) => {
+  //     return this._getPatchHandler(original);
+  //   };
+  // }
+
+  public getPatchHandler(original: Handler) {
+    this._getPatchHandler(original)
   }
 
   private _getPatchHandler(original: Handler) {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -444,27 +444,31 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
     lambdaResponse: any,
     errorFromLambda: string | Error | null | undefined,
   ) {
-    if (errorFromLambda) {
-      span.recordException(errorFromLambda);
+    if (span.isRecording()) {
+      if (errorFromLambda) {
+        span.recordException(errorFromLambda);
 
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: this._errorToString(errorFromLambda),
-      });
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: this._errorToString(errorFromLambda),
+        });
 
+        span.end();
+        return;
+      }
+
+      if (
+        this.triggerOrigin !== undefined &&
+        [TriggerOrigin.API_GATEWAY_REST, TriggerOrigin.API_GATEWAY_HTTP].includes(
+          this.triggerOrigin
+        )
+      ) {
+        finalizeSpan(config, this.triggerOrigin, span, lambdaResponse);
+      }
       span.end();
-      return;
+    } else {
+      diag.debug('Ending wrapper span for the second time');
     }
-
-    if (
-      this.triggerOrigin !== undefined &&
-      [TriggerOrigin.API_GATEWAY_REST, TriggerOrigin.API_GATEWAY_HTTP].includes(
-        this.triggerOrigin
-      )
-    ) {
-      finalizeSpan(config, this.triggerOrigin, span, lambdaResponse);
-    }
-    span.end();
   }
 
   private _wrapCallback(
@@ -516,18 +520,22 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
   }
 
   private _endSpan(span: Span, err: string | Error | null | undefined) {
-    if (err) {
-      span.recordException(err);
-    }
+    if (span.isRecording()) {
+      if (err) {
+        span.recordException(err);
+      }
 
-    const errMessage = this._errorToString(err);
-    if (errMessage) {
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: errMessage,
-      });
+      const errMessage = this._errorToString(err);
+      if (errMessage) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: errMessage,
+        });
+      }
+      span.end();
+    } else {
+      diag.debug('Ending span for the second time');
     }
-    span.end();
   }
 
   private _errorToString(err: string | Error | null | undefined) {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -228,11 +228,11 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
   //   };
   // }
 
-  public getPatchHandler(original: Handler) {
-    this._getPatchHandler(original)
+  public getPatchHandler(original: Handler): Handler {
+    return this._getPatchHandler(original)
   }
 
-  private _getPatchHandler(original: Handler) {
+  private _getPatchHandler(original: Handler): Handler {
     diag.debug('patch handler function');
     const plugin = this;
 

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-// import * as path from 'path';
-// import * as fs from 'fs';
-
 import {
   InstrumentationBase,
-  // InstrumentationNodeModuleDefinition,
-  // InstrumentationNodeModuleFile,
-  // isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import {
@@ -107,135 +101,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
   }
 
   init() {
-    // const taskRoot = process.env.LAMBDA_TASK_ROOT;
-    // const handlerDef = this._config.lambdaHandler ?? process.env._HANDLER;
-
-    // // _HANDLER and LAMBDA_TASK_ROOT are always defined in Lambda but guard bail out if in the future this changes.
-    // if (!taskRoot || !handlerDef) {
-    //   this._diag.debug(
-    //     'Skipping lambda instrumentation: no _HANDLER/lambdaHandler or LAMBDA_TASK_ROOT.',
-    //     { taskRoot, handlerDef }
-    //   );
-    //   return [];
-    // }
-
-    // const handler = path.basename(handlerDef);
-    // const moduleRoot = handlerDef.substr(0, handlerDef.length - handler.length);
-
-    // const [module, functionName] = handler.split('.', 2);
-
-    // // Lambda loads user function using an absolute path.
-    // let filename = path.resolve(taskRoot, moduleRoot, module);
-    // if (!filename.includes('.')) {
-    //   // The filename has no extension, we need to check if there is a .js, .cjs or .mjs file
-    //   try {
-    //     fs.statSync(`${filename}.js`);
-    //     filename += '.js';
-    //   } catch (e) {
-    //     try {
-    //       fs.statSync(`${filename}.cjs`);
-    //       filename += '.cjs';
-    //     } catch (e) {
-    //       try {
-    //         fs.statSync(`${filename}.mjs`);
-    //         filename += '.mjs';
-    //       } catch (e) {
-    //         diag.warn(`AwsLambdaInstrumentation couldn't find the handler file: ${filename}`);
-    //       }
-    //     }
-    //   }
-    // }
-
-    // diag.debug('Instrumenting lambda handler', {
-    //   taskRoot,
-    //   handlerDef,
-    //   handler,
-    //   moduleRoot,
-    //   module,
-    //   filename,
-    //   functionName,
-    // });
-
-    // return [
-    //   // This approach works when the handler is part of the function source code
-    //   new InstrumentationNodeModuleDefinition(
-    //     // NB: The patching infrastructure seems to match names backwards, this must be the filename, while
-    //     // InstrumentationNodeModuleFile must be the module name.
-    //     filename,
-    //     ['*'],
-    //     undefined,
-    //     undefined,
-    //     [
-    //       new InstrumentationNodeModuleFile(
-    //         module,
-    //         ['*'],
-    //         (moduleExports: LambdaModule) => {
-    //           diag.debug('Applying patch for lambda handler');
-    //           if (isWrapped(moduleExports[functionName])) {
-    //             this._unwrap(moduleExports, functionName);
-    //           }
-    //           this._wrap(moduleExports, functionName, this._getHandler());
-    //           return moduleExports;
-    //         },
-    //         (moduleExports?: LambdaModule) => {
-    //           if (moduleExports == null) return;
-    //           diag.debug('Removing patch for lambda handler');
-    //           this._unwrap(moduleExports, functionName);
-    //         }
-    //       ),
-    //     ]
-    //   ),
-    //   // This approach works when the handler is part of lambda layer
-    //   new InstrumentationNodeModuleDefinition(
-    //     module,
-    //     ['*'],
-    //     (moduleExports: LambdaModule) => {
-    //       diag.debug('Applying patch for lambda handler');
-    //       if (isWrapped(moduleExports[functionName])) {
-    //         this._unwrap(moduleExports, functionName);
-    //       }
-    //       this._wrap(moduleExports, functionName, this._getHandler());
-    //       return moduleExports;
-    //     },
-    //     (moduleExports?: LambdaModule) => {
-    //       if (moduleExports === undefined) return;
-    //       diag.debug('Removing patch for lambda handler');
-    //       this._unwrap(moduleExports, functionName);
-    //     }
-    //   ),
-    //   // This approach works when the handler is an .mjs file in the function source code
-    //   new InstrumentationNodeModuleDefinition(
-    //     filename,
-    //     ['*'],
-    //     (moduleExports: LambdaModule) => {
-    //       diag.debug('Applying patch for lambda handler');
-    //       if (isWrapped(moduleExports[functionName])) {
-    //         this._unwrap(moduleExports, functionName);
-    //       }
-    //       this._wrap(moduleExports, functionName, this._getHandler());
-    //       return moduleExports;
-    //     },
-    //     (moduleExports?: LambdaModule) => {
-    //       if (moduleExports === undefined) return;
-    //       diag.debug('Removing patch for lambda handler');
-    //       this._unwrap(moduleExports, functionName);
-    //     }
-    //   ),
-    // ];
     return [];
   }
 
-  // private _getHandler() {
-  //   return (original: Handler) => {
-  //     return this._getPatchHandler(original);
-  //   };
-  // }
-
   public getPatchHandler(original: Handler): Handler {
-    return this._getPatchHandler(original)
-  }
-
-  private _getPatchHandler(original: Handler): Handler {
     diag.debug('patch handler function');
     const plugin = this;
 


### PR DESCRIPTION
* Instead of patching handler function with the usual instrumentation infrastructure (hooking into require/import), expose the `getPatchHandler` so the handler can be patched "manually" by `opentelemetry-lambda`.
* Prevent closing spans that have already been closed (that happend when the user cod called callback twice) CDS-1290