### PR TITLE
Add esbuild plugin publishing

### DIFF
--- a/.github/workflows/publish-esbuild-plugin.yml
+++ b/.github/workflows/publish-esbuild-plugin.yml
@@ -13,6 +13,8 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm prune --production
+        working-directory: ./packages/esbuild-plugin-node
       - run: npm publish --access public
+        working-directory: ./packages/esbuild-plugin-node
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-esbuild-plugin.yml
+++ b/.github/workflows/publish-esbuild-plugin.yml
@@ -1,0 +1,18 @@
+name: Publish esbuild-plugin
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm prune --production
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-esbuild-plugin.yml
+++ b/.github/workflows/publish-esbuild-plugin.yml
@@ -12,9 +12,11 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-      - run: npm prune --production
+      - run: 
         working-directory: ./packages/esbuild-plugin-node
-      - run: npm publish --access public
+      - run: |
+            npm install
+            npm publish --access public
         working-directory: ./packages/esbuild-plugin-node
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
The plugin is here on a branch: https://github.com/coralogix/opentelemetry-js-contrib/tree/feature/NGSTN-1188-esbuild-plugin-test/packages/esbuild-plugin-node , still testing it. 

But I need to merge the workflow to the main branch, as only then the `workflow_dispatch` trigger can work.