### PR TITLE
Fix Lambda instrumentation package to match upstream's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37641,7 +37641,7 @@
       "version": "0.50.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.147"
       },
@@ -37653,7 +37653,7 @@
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@types/mocha": "7.0.2",
+        "@types/mocha": "10.0.10",
         "@types/node": "18.18.14",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -37667,9 +37667,9 @@
       }
     },
     "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true
     },
     "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@types/node": {
@@ -47769,7 +47769,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
         "@opentelemetry/propagator-aws-xray": "^1.26.2",
         "@opentelemetry/propagator-aws-xray-lambda": "^0.53.2",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -47777,7 +47777,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.147",
-        "@types/mocha": "7.0.2",
+        "@types/mocha": "10.0.10",
         "@types/node": "18.18.14",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -47785,9 +47785,9 @@
       },
       "dependencies": {
         "@types/mocha": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-          "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+          "version": "10.0.10",
+          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+          "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
           "dev": true
         },
         "@types/node": {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -49,14 +49,14 @@
     "@opentelemetry/sdk-metrics": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
-    "@types/mocha": "7.0.2",
+    "@types/mocha": "10.0.10",
     "@types/node": "18.18.14",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.57.1",
+    "@opentelemetry/instrumentation": "^0.57.2",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/aws-lambda": "8.10.147"
   },


### PR DESCRIPTION
Fixes ES-492.

Looks like this problem happened during the merge conflict resolution of the recent upgrade. 

I could only reproduce it locally after running an `npm run clean` in the folder of the `opentelemetry-instrumentation-aws-lambda` package.
